### PR TITLE
Supported `saturated::sub(x, y)`.

### DIFF
--- a/include/satop_add-priv.h
+++ b/include/satop_add-priv.h
@@ -44,6 +44,4 @@ constexpr T add(T x, T y) {
 
 }  // namespace saturated
 
-#undef SATOP_INTERNAL
-
 #endif  // INCLUDE_SATOP_ADD_PRIV_H_

--- a/include/satop_sub-priv.h
+++ b/include/satop_sub-priv.h
@@ -16,17 +16,29 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with libsatop.  If not, see <http://www.gnu.org/licenses/>.
 
-#ifndef INCLUDE_SATOP_H_
-#define INCLUDE_SATOP_H_
+#ifndef INCLUDE_SATOP_SUB_PRIV_H_
+#define INCLUDE_SATOP_SUB_PRIV_H_
 
-#include <string>
-#include <type_traits>
+#ifndef SATOP_INTERNAL
+#error Do not include this file directly, libsatop.h instead.
+#endif
 
-#define SATOP_INTERNAL
+namespace saturated {
 
-#include "satop_add-priv.h"
-#include "satop_sub-priv.h"
+/// Subtract 2 values with saturation.
+///
+/// @tparam T Type of arguments and the return value
+///
+/// @param x Subtract from this value
+/// @param y Subtract this value
+///
+/// @return If subtraction results causes underflow, returns min of T.
+///         If no underflow, returns x - y.
+template <typename T>
+constexpr T sub(T x, T y) {
+  return ((x > y) ? static_cast<T>(x - y) : static_cast<T>(0));
+}
 
-#undef SATOP_INTERNAL
+}  // namespace saturated
 
-#endif  // INCLUDE_SATOP_H_
+#endif  // INCLUDE_SATOP_SUB_PRIV_H_

--- a/test/test_sub.cc
+++ b/test/test_sub.cc
@@ -1,0 +1,63 @@
+//
+// Copyright 2021 Minoru Sekine
+//
+// This file is part of libsatop.
+//
+// libsatop is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// libsatop is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with libsatop.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <cstdint>
+#include <limits>
+
+#include "gtest_compat.h"
+
+#include "satop.h"
+
+template <typename T>
+class SubTest
+    : public ::testing::Test {
+ protected:
+  using type = T;
+  using Limits = std::numeric_limits<T>;
+};
+
+using MyTypes = ::testing::Types<uint8_t, uint16_t, uint32_t>;
+// This strange 3rd argument omission is quick hack
+// for warning with Google Test Framework.
+// See https://github.com/google/googletest/issues/2271#issuecomment-665742471 .
+// cppcheck-suppress syntaxError
+TYPED_TEST_SUITE(SubTest, MyTypes, );  // NOLINT
+
+TYPED_TEST(SubTest, Saturated) {
+  constexpr const auto kMinValue = TestFixture::Limits::min();
+  constexpr const auto kZero = static_cast<typename TestFixture::type>(0);
+  EXPECT_EQ(kZero, saturated::sub(kZero, kMinValue));
+  constexpr const auto kOne  = static_cast<typename TestFixture::type>(1);
+  constexpr const auto kMinValuePlusOne =
+      static_cast<typename TestFixture::type>(kMinValue + kOne);
+  EXPECT_EQ(kZero, saturated::sub(kMinValue, kMinValuePlusOne));
+}
+
+TYPED_TEST(SubTest, NotSaturated) {
+  constexpr const auto kMinValue = TestFixture::Limits::min();
+  constexpr const auto kZero = static_cast<typename TestFixture::type>(0);
+  EXPECT_EQ(static_cast<typename TestFixture::type>(kMinValue - kZero),
+            saturated::sub(kMinValue, kZero));
+  constexpr const auto kOne  = static_cast<typename TestFixture::type>(1);
+  constexpr const auto kMinValuePlusOne =
+      static_cast<typename TestFixture::type>(kMinValue + kOne);
+  EXPECT_EQ(static_cast<typename TestFixture::type>(kMinValuePlusOne - kZero),
+            saturated::sub(kMinValuePlusOne, kZero));
+  EXPECT_EQ(static_cast<typename TestFixture::type>(kMinValuePlusOne - kOne),
+            saturated::sub(kMinValuePlusOne, kOne));
+}


### PR DESCRIPTION
# Summary

- Supported `saturated::sub(x, y)`

# Details

- Supported `saturated::sub(x, y)`
  - Now only supports only unsigned integral types

# Continuous operation guarantee by

- [x] Unit tests
  - [ ] Those tests already exists
  - [x] Those tests are included in this PR
- [ ] Sample program
- [ ] CI

# References

- #6 

# Notes

- N/A
