### PR TITLE
Support signed integral types in `saturated::add()`.

### DIFF
--- a/test/test_add.cc
+++ b/test/test_add.cc
@@ -28,9 +28,11 @@ class AddOverflowTest
     : public ::testing::Test {
  protected:
   using Limits = std::numeric_limits<T>;
+  using test_target_t = T;
 };
 
-using TypesForOverflowTests = ::testing::Types<uint8_t, uint16_t, uint32_t>;
+using TypesForOverflowTests = ::testing::Types<uint8_t, uint16_t, uint32_t,
+                                               int8_t, int16_t, int32_t>;
 // This strange 3rd argument omission is quick hack
 // for warning with Google Test Framework.
 // See https://github.com/google/googletest/issues/2271#issuecomment-665742471 .
@@ -39,9 +41,9 @@ TYPED_TEST_SUITE(AddOverflowTest, TypesForOverflowTests, );  // NOLINT
 
 TYPED_TEST(AddOverflowTest, Overflow) {
   constexpr const auto kMaxValue = TestFixture::Limits::max();
-  constexpr const auto kMinValue = TestFixture::Limits::min();
-  EXPECT_EQ(kMaxValue, saturated::add(kMaxValue, kMinValue));
-  EXPECT_EQ(kMaxValue, saturated::add(kMinValue, kMaxValue));
+  constexpr const typename TestFixture::test_target_t kPositiveMinValue(1);
+  EXPECT_EQ(kMaxValue, saturated::add(kMaxValue, kPositiveMinValue));
+  EXPECT_EQ(kMaxValue, saturated::add(kPositiveMinValue, kMaxValue));
   EXPECT_EQ(kMaxValue, saturated::add(kMaxValue, kMaxValue));
 }
 
@@ -50,4 +52,33 @@ TYPED_TEST(AddOverflowTest, NotOverflow) {
   constexpr const decltype(x) y = 1;
   EXPECT_EQ(x + y, saturated::add(x, y));
   EXPECT_EQ(x + y, saturated::add(y, x));
+}
+
+template <typename T>
+class AddUnderflowTest
+    : public ::testing::Test {
+ protected:
+  using Limits = std::numeric_limits<T>;
+  using test_target_t = T;
+};
+
+using TypesForUnderflowTests = ::testing::Types<int8_t, int16_t, int32_t>;
+// This strange 3rd argument omission is quick hack
+// for warning with Google Test Framework.
+// See https://github.com/google/googletest/issues/2271#issuecomment-665742471 .
+TYPED_TEST_SUITE(AddUnderflowTest, TypesForUnderflowTests, );  // NOLINT
+
+TYPED_TEST(AddUnderflowTest, Underflow) {
+  constexpr const auto kLowest = TestFixture::Limits::lowest();
+  constexpr const typename TestFixture::test_target_t kMinusOne(-1);
+  EXPECT_EQ(kLowest, saturated::add(kLowest, kMinusOne));
+  EXPECT_EQ(kLowest, saturated::add(kMinusOne, kLowest));
+  EXPECT_EQ(kLowest, saturated::add(kLowest, kLowest));
+}
+
+TYPED_TEST(AddUnderflowTest, NotUnderflow) {
+  constexpr const typename TestFixture::test_target_t kMinusOne(-1);
+  EXPECT_EQ(
+      static_cast<typename TestFixture::test_target_t>(kMinusOne + kMinusOne),
+      saturated::add(kMinusOne, kMinusOne));
 }

--- a/test/test_add.cc
+++ b/test/test_add.cc
@@ -24,20 +24,20 @@
 #include "satop.h"
 
 template <typename T>
-class AddTest
+class AddOverflowTest
     : public ::testing::Test {
  protected:
   using Limits = std::numeric_limits<T>;
 };
 
-using MyTypes = ::testing::Types<uint8_t, uint16_t, uint32_t>;
+using TypesForOverflowTests = ::testing::Types<uint8_t, uint16_t, uint32_t>;
 // This strange 3rd argument omission is quick hack
 // for warning with Google Test Framework.
 // See https://github.com/google/googletest/issues/2271#issuecomment-665742471 .
 // cppcheck-suppress syntaxError
-TYPED_TEST_SUITE(AddTest, MyTypes, );  // NOLINT
+TYPED_TEST_SUITE(AddOverflowTest, TypesForOverflowTests, );  // NOLINT
 
-TYPED_TEST(AddTest, Saturated) {
+TYPED_TEST(AddOverflowTest, Overflow) {
   constexpr const auto kMaxValue = TestFixture::Limits::max();
   constexpr const auto kMinValue = TestFixture::Limits::min();
   EXPECT_EQ(kMaxValue, saturated::add(kMaxValue, kMinValue));
@@ -45,7 +45,7 @@ TYPED_TEST(AddTest, Saturated) {
   EXPECT_EQ(kMaxValue, saturated::add(kMaxValue, kMaxValue));
 }
 
-TYPED_TEST(AddTest, NotSaturated) {
+TYPED_TEST(AddOverflowTest, NotOverflow) {
   constexpr const auto x = TestFixture::Limits::max() - 2;
   constexpr const decltype(x) y = 1;
   EXPECT_EQ(x + y, saturated::add(x, y));

--- a/test/test_add.cc
+++ b/test/test_add.cc
@@ -38,11 +38,11 @@ using MyTypes = ::testing::Types<uint8_t, uint16_t, uint32_t>;
 TYPED_TEST_SUITE(AddTest, MyTypes, );  // NOLINT
 
 TYPED_TEST(AddTest, Saturated) {
-  constexpr const auto max_value = TestFixture::Limits::max();
-  constexpr const auto min_value = TestFixture::Limits::min();
-  EXPECT_EQ(max_value, saturated::add(max_value, min_value));
-  EXPECT_EQ(max_value, saturated::add(min_value, max_value));
-  EXPECT_EQ(max_value, saturated::add(max_value, max_value));
+  constexpr const auto kMaxValue = TestFixture::Limits::max();
+  constexpr const auto kMinValue = TestFixture::Limits::min();
+  EXPECT_EQ(kMaxValue, saturated::add(kMaxValue, kMinValue));
+  EXPECT_EQ(kMaxValue, saturated::add(kMinValue, kMaxValue));
+  EXPECT_EQ(kMaxValue, saturated::add(kMaxValue, kMaxValue));
 }
 
 TYPED_TEST(AddTest, NotSaturated) {

--- a/test/test_add.cc
+++ b/test/test_add.cc
@@ -48,7 +48,9 @@ TYPED_TEST(AddOverflowTest, Overflow) {
 }
 
 TYPED_TEST(AddOverflowTest, NotOverflow) {
-  constexpr const auto x = TestFixture::Limits::max() - 2;
+  constexpr const auto x =
+      static_cast<typename TestFixture::test_target_t>(
+          TestFixture::Limits::max() - 2);
   constexpr const decltype(x) y = 1;
   EXPECT_EQ(x + y, saturated::add(x, y));
   EXPECT_EQ(x + y, saturated::add(y, x));


### PR DESCRIPTION
# Summary

- Support signed integral types in `saturated::add()`

# Details

- Support signed overflow
- Support underflow by adding negative numbers

# Continuous operation guarantee by

- [x] Unit tests
  - [x] Those tests already exists
  - [x] Those tests are included in this PR
- [ ] Sample program
- [ ] CI

# References

- #14 

# Notes

- N/A
