### PR TITLE
Support signed integer types in `saturated::sub()`.

### DIFF
--- a/include/satop_add-priv.h
+++ b/include/satop_add-priv.h
@@ -37,15 +37,16 @@ constexpr T is_add_overflow(T x, T y) {
 }
 
 template <typename T>
-constexpr auto is_add_underflow(T x, T y)
-    -> typename std::enable_if<std::is_unsigned<T>::value, T>::type {
+constexpr bool is_add_underflow(
+    T x,
+    typename std::enable_if<std::is_unsigned<T>::value, T>::type y) {
   return static_cast<void>(x), static_cast<void>(y), false;
 }
 
 template <typename T>
-constexpr auto is_add_underflow(T x, T y)
-    -> typename std::enable_if<std::is_signed<T>::value, T>::type {
-  // return (x < std::numeric_limits<T>::min() - y);
+constexpr bool is_add_underflow(
+    T x,
+    typename std::enable_if<std::is_signed<T>::value, T>::type y) {
   return ((x < 0)
           && (y < 0)
           && ((x < std::numeric_limits<T>::min() - y)

--- a/include/satop_sub-priv.h
+++ b/include/satop_sub-priv.h
@@ -24,14 +24,33 @@
 #endif
 
 #include <limits>
+#include <type_traits>
 
 namespace saturated {
 
 namespace impl {
 
 template <typename T>
-constexpr bool is_sub_underflow(T x, T y) {
-  return (x < std::numeric_limits<T>::lowest() + y);
+constexpr bool is_sub_underflow(
+    T x,
+    typename std::enable_if<std::is_signed<T>::value, T>::type y) {
+  return ((x < 0)
+          && (y > 0)
+          && (x < std::numeric_limits<T>::lowest() + y));
+}
+
+template <typename T>
+constexpr bool is_sub_underflow(
+    T x,
+    typename std::enable_if<std::is_unsigned<T>::value, T>::type y) {
+  return (x < y);
+}
+
+template <typename T>
+constexpr bool is_sub_overflow(T x, T y) {
+  return ((x > 0)
+          && (y < 0)
+          && (x > std::numeric_limits<T>::max() + y));
 }
 
 }  // namespace impl
@@ -49,7 +68,9 @@ template <typename T>
 constexpr T sub(T x, T y) {
   return (impl::is_sub_underflow(x, y)
           ? std::numeric_limits<T>::lowest()
-          : static_cast<T>(x - y));
+          : (impl::is_sub_overflow(x, y)
+             ? std::numeric_limits<T>::max()
+             : static_cast<T>(x - y)));
 }
 
 }  // namespace saturated

--- a/include/satop_sub-priv.h
+++ b/include/satop_sub-priv.h
@@ -23,7 +23,18 @@
 #error Do not include this file directly, libsatop.h instead.
 #endif
 
+#include <limits>
+
 namespace saturated {
+
+namespace impl {
+
+template <typename T>
+constexpr bool is_sub_underflow(T x, T y) {
+  return (x < std::numeric_limits<T>::lowest() + y);
+}
+
+}  // namespace impl
 
 /// Subtract 2 values with saturation.
 ///
@@ -36,7 +47,9 @@ namespace saturated {
 ///         If no underflow, returns x - y.
 template <typename T>
 constexpr T sub(T x, T y) {
-  return ((x > y) ? static_cast<T>(x - y) : static_cast<T>(0));
+  return (impl::is_sub_underflow(x, y)
+          ? std::numeric_limits<T>::lowest()
+          : static_cast<T>(x - y));
 }
 
 }  // namespace saturated

--- a/test/test_sub.cc
+++ b/test/test_sub.cc
@@ -40,24 +40,25 @@ TYPED_TEST_SUITE(SubTest, MyTypes, );  // NOLINT
 
 TYPED_TEST(SubTest, Underflow) {
   constexpr const auto kMinValue = TestFixture::Limits::min();
-  constexpr const auto kZero = static_cast<typename TestFixture::type>(0);
-  EXPECT_EQ(kZero, saturated::sub(kZero, kMinValue));
+  constexpr const auto kLowestValue = TestFixture::Limits::lowest();
+  EXPECT_EQ(kLowestValue, saturated::sub(kLowestValue, kMinValue));
   constexpr const auto kOne  = static_cast<typename TestFixture::type>(1);
-  constexpr const auto kMinValuePlusOne =
-      static_cast<typename TestFixture::type>(kMinValue + kOne);
-  EXPECT_EQ(kZero, saturated::sub(kMinValue, kMinValuePlusOne));
+  constexpr const auto kLowestValuePlusOne =
+      static_cast<typename TestFixture::type>(kLowestValue + kOne);
+  EXPECT_EQ(kLowestValue, saturated::sub(kLowestValue, kLowestValuePlusOne));
 }
 
 TYPED_TEST(SubTest, NotUnderflow) {
-  constexpr const auto kMinValue = TestFixture::Limits::min();
+  constexpr const auto kLowestValue = TestFixture::Limits::lowest();
   constexpr const auto kZero = static_cast<typename TestFixture::type>(0);
-  EXPECT_EQ(static_cast<typename TestFixture::type>(kMinValue - kZero),
-            saturated::sub(kMinValue, kZero));
+  EXPECT_EQ(static_cast<typename TestFixture::type>(kLowestValue - kZero),
+            saturated::sub(kLowestValue, kZero));
   constexpr const auto kOne  = static_cast<typename TestFixture::type>(1);
-  constexpr const auto kMinValuePlusOne =
-      static_cast<typename TestFixture::type>(kMinValue + kOne);
-  EXPECT_EQ(static_cast<typename TestFixture::type>(kMinValuePlusOne - kZero),
-            saturated::sub(kMinValuePlusOne, kZero));
-  EXPECT_EQ(static_cast<typename TestFixture::type>(kMinValuePlusOne - kOne),
-            saturated::sub(kMinValuePlusOne, kOne));
+  constexpr const auto kLowestValuePlusOne =
+      static_cast<typename TestFixture::type>(kLowestValue + kOne);
+  EXPECT_EQ(
+      static_cast<typename TestFixture::type>(kLowestValuePlusOne - kZero),
+      saturated::sub(kLowestValuePlusOne, kZero));
+  EXPECT_EQ(static_cast<typename TestFixture::type>(kLowestValuePlusOne - kOne),
+            saturated::sub(kLowestValuePlusOne, kOne));
 }

--- a/test/test_sub.cc
+++ b/test/test_sub.cc
@@ -38,7 +38,7 @@ using MyTypes = ::testing::Types<uint8_t, uint16_t, uint32_t>;
 // cppcheck-suppress syntaxError
 TYPED_TEST_SUITE(SubTest, MyTypes, );  // NOLINT
 
-TYPED_TEST(SubTest, Saturated) {
+TYPED_TEST(SubTest, Underflow) {
   constexpr const auto kMinValue = TestFixture::Limits::min();
   constexpr const auto kZero = static_cast<typename TestFixture::type>(0);
   EXPECT_EQ(kZero, saturated::sub(kZero, kMinValue));
@@ -48,7 +48,7 @@ TYPED_TEST(SubTest, Saturated) {
   EXPECT_EQ(kZero, saturated::sub(kMinValue, kMinValuePlusOne));
 }
 
-TYPED_TEST(SubTest, NotSaturated) {
+TYPED_TEST(SubTest, NotUnderflow) {
   constexpr const auto kMinValue = TestFixture::Limits::min();
   constexpr const auto kZero = static_cast<typename TestFixture::type>(0);
   EXPECT_EQ(static_cast<typename TestFixture::type>(kMinValue - kZero),

--- a/test/test_sub.cc
+++ b/test/test_sub.cc
@@ -24,31 +24,28 @@
 #include "satop.h"
 
 template <typename T>
-class SubTest
+class SubUnderflowTests
     : public ::testing::Test {
  protected:
   using type = T;
   using Limits = std::numeric_limits<T>;
 };
 
-using MyTypes = ::testing::Types<uint8_t, uint16_t, uint32_t>;
+using TypesForSubUnderflowTests = ::testing::Types<uint8_t, uint16_t, uint32_t,
+                                 int8_t, int16_t, int32_t>;
 // This strange 3rd argument omission is quick hack
 // for warning with Google Test Framework.
 // See https://github.com/google/googletest/issues/2271#issuecomment-665742471 .
 // cppcheck-suppress syntaxError
-TYPED_TEST_SUITE(SubTest, MyTypes, );  // NOLINT
+TYPED_TEST_SUITE(SubUnderflowTests, TypesForSubUnderflowTests, );  // NOLINT
 
-TYPED_TEST(SubTest, Underflow) {
-  constexpr const auto kMinValue = TestFixture::Limits::min();
-  constexpr const auto kLowestValue = TestFixture::Limits::lowest();
-  EXPECT_EQ(kLowestValue, saturated::sub(kLowestValue, kMinValue));
+TYPED_TEST(SubUnderflowTests, Underflow) {
   constexpr const auto kOne  = static_cast<typename TestFixture::type>(1);
-  constexpr const auto kLowestValuePlusOne =
-      static_cast<typename TestFixture::type>(kLowestValue + kOne);
-  EXPECT_EQ(kLowestValue, saturated::sub(kLowestValue, kLowestValuePlusOne));
+  constexpr const auto kLowestValue = TestFixture::Limits::lowest();
+  EXPECT_EQ(kLowestValue, saturated::sub(kLowestValue, kOne));
 }
 
-TYPED_TEST(SubTest, NotUnderflow) {
+TYPED_TEST(SubUnderflowTests, NotUnderflow) {
   constexpr const auto kLowestValue = TestFixture::Limits::lowest();
   constexpr const auto kZero = static_cast<typename TestFixture::type>(0);
   EXPECT_EQ(static_cast<typename TestFixture::type>(kLowestValue - kZero),
@@ -61,4 +58,30 @@ TYPED_TEST(SubTest, NotUnderflow) {
       saturated::sub(kLowestValuePlusOne, kZero));
   EXPECT_EQ(static_cast<typename TestFixture::type>(kLowestValuePlusOne - kOne),
             saturated::sub(kLowestValuePlusOne, kOne));
+}
+
+template <typename T>
+class SubOverflowTests
+    : public ::testing::Test {
+ protected:
+  using type = T;
+  using Limits = std::numeric_limits<T>;
+};
+
+using TypesForSubOverflowTests = ::testing::Types<int8_t, int16_t, int32_t>;
+// This strange 3rd argument omission is quick hack
+// for warning with Google Test Framework.
+// See https://github.com/google/googletest/issues/2271#issuecomment-665742471 .
+TYPED_TEST_SUITE(SubOverflowTests, TypesForSubOverflowTests, );  // NOLINT
+
+TYPED_TEST(SubOverflowTests, Overflow) {
+  constexpr const auto kOne  = static_cast<typename TestFixture::type>(1);
+  constexpr const auto kLowestValue = TestFixture::Limits::lowest();
+  constexpr const auto kMaxValue = TestFixture::Limits::max();
+  EXPECT_EQ(kMaxValue, saturated::sub(kOne, kLowestValue));
+}
+
+TYPED_TEST(SubOverflowTests, NotOverflow) {
+  constexpr const auto kMinusOne = static_cast<typename TestFixture::type>(-1);
+  EXPECT_EQ(kMinusOne - kMinusOne, saturated::sub(kMinusOne, kMinusOne));
 }


### PR DESCRIPTION
# Summary

- Support signed integer types in `saturated::sub()`

# Details

- Support signed integer types in `saturated::sub()`
- Some refactorings for that

# Continuous operation guarantee by

- [x] Unit tests
  - [x] Those tests already exists
  - [x] Those tests are included in this PR
- [ ] Sample program
- [ ] CI

# References

- #15 

# Notes

- N/A
