### PR TITLE
Supported `saturated::div()`.

### DIFF
--- a/include/satop.h
+++ b/include/satop.h
@@ -25,6 +25,7 @@
 #define SATOP_INTERNAL
 
 #include "satop_add-priv.h"
+#include "satop_div-priv.h"
 #include "satop_mul-priv.h"
 #include "satop_sub-priv.h"
 

--- a/include/satop_div-priv.h
+++ b/include/satop_div-priv.h
@@ -1,0 +1,55 @@
+//
+// Copyright 2021 Minoru Sekine
+//
+// This file is part of libsatop.
+//
+// libsatop is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// libsatop is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with libsatop.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef INCLUDE_SATOP_DIV_PRIV_H_
+#define INCLUDE_SATOP_DIV_PRIV_H_
+
+#ifndef SATOP_INTERNAL
+#error Do not include this file directly, libsatop.h instead.
+#endif
+
+#include <limits>
+
+#include "satop_sign_util-priv.h"
+
+namespace saturated {
+
+/// @addtogroup libsatop
+///
+/// @{
+
+/// Divide 2 values with saturation.
+///
+/// @tparam T Type of arguments and the return value
+///
+/// @param x A value to divtiply
+/// @param y A value to divtiply
+///
+/// @return If divtiply results causes overflow, returns max of T.
+///         If underflow, returns min(lowest) of T.
+///         If no overflow and no underflow, returns x + y.
+template <typename T>
+constexpr T div(T x, T y) {
+  return static_cast<T>(x / y);
+}
+
+/// @}
+
+}  // namespace saturated
+
+#endif  // INCLUDE_SATOP_DIV_PRIV_H_

--- a/include/satop_mul-priv.h
+++ b/include/satop_mul-priv.h
@@ -44,7 +44,6 @@ constexpr bool is_mul_underflow(T x, T y) {
               || (y < std::numeric_limits<T>::lowest() / x)));
 }
 
-
 }  // namespace impl
 
 /// @addtogroup libsatop

--- a/test/test_div.cc
+++ b/test/test_div.cc
@@ -1,0 +1,49 @@
+//
+// Copyright 2021 Minoru Sekine
+//
+// This file is part of libsatop.
+//
+// libsatop is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// libsatop is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with libsatop.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <cstdint>
+#include <limits>
+
+#include "gtest_compat.h"
+
+#include "satop.h"
+
+template <typename T>
+class DivOverflowTest
+    : public ::testing::Test {
+ protected:
+  using Limits = std::numeric_limits<T>;
+  using test_target_t = T;
+};
+
+using TypesForOverflowTests = ::testing::Types<uint8_t, uint16_t, uint32_t,
+                                               int8_t, int16_t, int32_t>;
+// This strange 3rd argument omission is quick hack
+// for warning with Google Test Framework.
+// See https://github.com/google/googletest/issues/2271#issuecomment-665742471 .
+// cppcheck-suppress syntaxError
+TYPED_TEST_SUITE(DivOverflowTest, TypesForOverflowTests, );  // NOLINT
+
+TYPED_TEST(DivOverflowTest, NotOverflow) {
+  constexpr const auto kMaxValue = TestFixture::Limits::max();
+  constexpr const typename TestFixture::test_target_t kOne(1);
+  EXPECT_EQ(kMaxValue, saturated::div(kMaxValue, kOne));
+  EXPECT_EQ(static_cast<typename TestFixture::test_target_t>(kOne / kMaxValue),
+            saturated::div(kOne, kMaxValue));
+  EXPECT_EQ(kOne, saturated::div(kMaxValue, kMaxValue));
+}

--- a/test/test_mul.cc
+++ b/test/test_mul.cc
@@ -39,7 +39,7 @@ T GetRootOfMax() {
 }  // namespace
 
 template <typename T>
-class AddOverflowTest
+class MulOverflowTest
     : public ::testing::Test {
  protected:
   using Limits = std::numeric_limits<T>;
@@ -52,9 +52,9 @@ using TypesForOverflowTests = ::testing::Types<uint8_t, uint16_t, uint32_t,
 // for warning with Google Test Framework.
 // See https://github.com/google/googletest/issues/2271#issuecomment-665742471 .
 // cppcheck-suppress syntaxError
-TYPED_TEST_SUITE(AddOverflowTest, TypesForOverflowTests, );  // NOLINT
+TYPED_TEST_SUITE(MulOverflowTest, TypesForOverflowTests, );  // NOLINT
 
-TYPED_TEST(AddOverflowTest, Overflow) {
+TYPED_TEST(MulOverflowTest, Overflow) {
   constexpr const auto kMaxValue = TestFixture::Limits::max();
   constexpr const typename TestFixture::test_target_t kTwo(2);
   EXPECT_EQ(kMaxValue, saturated::mul(kMaxValue, kTwo));
@@ -67,7 +67,7 @@ TYPED_TEST(AddOverflowTest, Overflow) {
   EXPECT_EQ(kMaxValue, saturated::mul(kRootOfMaxPlus1, kRootOfMaxPlus1));
 }
 
-TYPED_TEST(AddOverflowTest, NotOverflow) {
+TYPED_TEST(MulOverflowTest, NotOverflow) {
   constexpr const auto kMaxValue = TestFixture::Limits::max();
   constexpr const typename TestFixture::test_target_t kOne(1);
   EXPECT_EQ(kMaxValue, saturated::mul(kMaxValue, kOne));


### PR DESCRIPTION
# Summary

- Supported `saturated::div()`

# Details

- Supported `saturated::div()`
- Some refactorings
  - Removed redundant consecutive blank lines
  - Renamed not-suitable test name

# Continuous operation guarantee by

- [x] Unit tests
  - [x] Those tests already exists
  - [x] Those tests are included in this PR
- [ ] Sample program
- [ ] CI

# References

- #21 

# Notes

- N/A
