### PR TITLE
feat: Enable manually invoking GitHub Actions workflows. (#34)

### DIFF
--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install graphviz, doxygen, and TeX
         run: |

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   schedule:
     - cron: 0 20 * * 5
+  workflow_dispatch:
 
 jobs:
   Doxygen:

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -3,27 +3,27 @@ name: Doxygen
 on:
   pull_request:
   schedule:
-    - cron:  0 20 * * 5
+    - cron: 0 20 * * 5
 
 jobs:
   Doxygen:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Install graphviz, doxygen, and TeX
-      run: |
-        sudo apt update
-        sudo apt install -y --no-install-recommends graphviz doxygen
-        sudo apt install -y texlive-latex-extra
+      - name: Install graphviz, doxygen, and TeX
+        run: |
+          sudo apt update
+          sudo apt install -y --no-install-recommends graphviz doxygen
+          sudo apt install -y texlive-latex-extra
 
-    - name: Make Doxygen documents
-      run: |
-        make -k -j doxygen latex pdf
+      - name: Make Doxygen documents
+        run: |
+          make -k -j doxygen latex pdf
 
-    - name: Upload Doxygen documents
-      uses: actions/upload-artifact@v1
-      with:
-        name: doc
-        path: out/site/Doxygen
+      - name: Upload Doxygen documents
+        uses: actions/upload-artifact@v1
+        with:
+          name: doc
+          path: out/site/Doxygen

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   schedule:
     - cron: 0 20 * * 5
+  workflow_dispatch:
 
 jobs:
   tests:

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -3,7 +3,7 @@ name: Check build
 on:
   pull_request:
   schedule:
-    - cron:  0 20 * * 5
+    - cron: 0 20 * * 5
 
 jobs:
   tests:
@@ -21,44 +21,44 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
-    - if: contains(matrix.os, 'windows')
-      uses: microsoft/setup-msbuild@v1.0.2
+      - uses: actions/checkout@v2
+      - if: contains(matrix.os, 'windows')
+        uses: microsoft/setup-msbuild@v1.0.2
 
-    - name: Install googletest
-      if: contains(matrix.os, 'macOS') || contains(matrix.os, 'ubuntu')
-      run: |
-        git clone https://github.com/google/googletest.git
-        cd googletest
-        cmake -DBUILD_GMOCK=OFF -DCMAKE_CXX_STANDARD=11 .
-        sudo make -k -j all install
+      - name: Install googletest
+        if: contains(matrix.os, 'macOS') || contains(matrix.os, 'ubuntu')
+        run: |
+          git clone https://github.com/google/googletest.git
+          cd googletest
+          cmake -DBUILD_GMOCK=OFF -DCMAKE_CXX_STANDARD=11 .
+          sudo make -k -j all install
 
-    - name: Restore nuget packages (Windows)
-      if: contains(matrix.os, 'windows')
-      run: |
-        nuget restore build/win_vs/libsatop/libsatop.sln
+      - name: Restore nuget packages (Windows)
+        if: contains(matrix.os, 'windows')
+        run: |
+          nuget restore build/win_vs/libsatop/libsatop.sln
 
-    - name: Build tests (Ubuntu, macOS)
-      if: contains(matrix.os, 'macOS') || contains(matrix.os, 'ubuntu')
-      run: |
-        make BUILD_TYPE=${{ matrix.build_type }} -k -j build-test
+      - name: Build tests (Ubuntu, macOS)
+        if: contains(matrix.os, 'macOS') || contains(matrix.os, 'ubuntu')
+        run: |
+          make BUILD_TYPE=${{ matrix.build_type }} -k -j build-test
 
-    - name: Build tests (Windows)
-      if: contains(matrix.os, 'windows')
-      run: |
-        msbuild build/win_vs/libsatop/libsatop_test/libsatop_test.vcxproj /t:build /p:Configuration=${{ matrix.build_type }} /p:Platform="${{ matrix.platform }}" /maxCpuCount
+      - name: Build tests (Windows)
+        if: contains(matrix.os, 'windows')
+        run: |
+          msbuild build/win_vs/libsatop/libsatop_test/libsatop_test.vcxproj /t:build /p:Configuration=${{ matrix.build_type }} /p:Platform="${{ matrix.platform }}" /maxCpuCount
 
-    - name: Run tests (Ubuntu, macOS)
-      if: contains(matrix.os, 'macOS') || contains(matrix.os, 'ubuntu')
-      run: |
-        make BUILD_TYPE=${{ matrix.build_type }} -k -j run-test
+      - name: Run tests (Ubuntu, macOS)
+        if: contains(matrix.os, 'macOS') || contains(matrix.os, 'ubuntu')
+        run: |
+          make BUILD_TYPE=${{ matrix.build_type }} -k -j run-test
 
-    - name: Run tests (Windows)
-      if: contains(matrix.os, 'windows')
-      run: |
-        out\\${{ matrix.platform }}\\${{ matrix.build_type }}\\libsatop_test\\libsatop_test.exe
+      - name: Run tests (Windows)
+        if: contains(matrix.os, 'windows')
+        run: |
+          out\\${{ matrix.platform }}\\${{ matrix.build_type }}\\libsatop_test\\libsatop_test.exe
 
-    - name: Test `make clean` works fine (Ubuntu, macOS)
-      if: contains(matrix.os, 'macOS') || contains(matrix.os, 'ubuntu')
-      run: |
-        make BUILD_TYPE=${{ matrix.build_type }} -k -j clean
+      - name: Test `make clean` works fine (Ubuntu, macOS)
+        if: contains(matrix.os, 'macOS') || contains(matrix.os, 'ubuntu')
+        run: |
+          make BUILD_TYPE=${{ matrix.build_type }} -k -j clean

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - if: contains(matrix.os, 'windows')
         uses: microsoft/setup-msbuild@v1.0.2
 

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -3,7 +3,7 @@ name: cppcheck
 on:
   pull_request:
   schedule:
-    - cron:  0 20 * * 5
+    - cron: 0 20 * * 5
 
 jobs:
   cppcheck:
@@ -17,33 +17,33 @@ jobs:
       CPPCHECK_MAKE_OPTIONS: -k -j MATCHCOMPILER=yes FILESDIR=/usr/share/cppcheck HAVE_RULES=yes CXXFLAGS='-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function'
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Cache cppcheck (Ubuntu)
-      if: contains(matrix.os, 'ubuntu')
-      id: cache_cppcheck
-      uses: actions/cache@v2
-      with:
-        path: cppcheck
-        key: cppcheck_cache_${{ runner.os }}_v1
+      - name: Cache cppcheck (Ubuntu)
+        if: contains(matrix.os, 'ubuntu')
+        id: cache_cppcheck
+        uses: actions/cache@v2
+        with:
+          path: cppcheck
+          key: cppcheck_cache_${{ runner.os }}_v1
 
-    - name: Clone cppcheck to install (Ubuntu)
-      if: contains(matrix.os, 'ubuntu') && steps.cache_cppcheck.outputs.cache-hit != 'true'
-      run: |
-        git clone --depth=1 https://github.com/danmar/cppcheck.git
+      - name: Clone cppcheck to install (Ubuntu)
+        if: contains(matrix.os, 'ubuntu') && steps.cache_cppcheck.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth=1 https://github.com/danmar/cppcheck.git
 
-    - name: Build cppcheck (Ubuntu)
-      if: contains(matrix.os, 'ubuntu') && steps.cache_cppcheck.outputs.cache-hit != 'true'
-      run: |
-        cd cppcheck
-        sudo make ${{ env.CPPCHECK_MAKE_OPTIONS }} all
+      - name: Build cppcheck (Ubuntu)
+        if: contains(matrix.os, 'ubuntu') && steps.cache_cppcheck.outputs.cache-hit != 'true'
+        run: |
+          cd cppcheck
+          sudo make ${{ env.CPPCHECK_MAKE_OPTIONS }} all
 
-    - name: Install cppcheck (Ubuntu)
-      if: contains(matrix.os, 'ubuntu')
-      run: |
-        cd cppcheck
-        sudo make ${{ env.CPPCHECK_MAKE_OPTIONS }} install
+      - name: Install cppcheck (Ubuntu)
+        if: contains(matrix.os, 'ubuntu')
+        run: |
+          cd cppcheck
+          sudo make ${{ env.CPPCHECK_MAKE_OPTIONS }} install
 
-    - name: Run cppcheck
-      run: |
-        make -k -j cppcheck
+      - name: Run cppcheck
+        run: |
+          make -k -j cppcheck

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -8,11 +8,7 @@ on:
 
 jobs:
   cppcheck:
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     env:
       CPPCHECK_MAKE_OPTIONS: -k -j MATCHCOMPILER=yes FILESDIR=/usr/share/cppcheck HAVE_RULES=yes CXXFLAGS='-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function'
@@ -20,27 +16,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache cppcheck (Ubuntu)
-        if: contains(matrix.os, 'ubuntu')
+      - name: Cache cppcheck
         id: cache_cppcheck
         uses: actions/cache@v2
         with:
           path: cppcheck
           key: cppcheck_cache_${{ runner.os }}_v1
 
-      - name: Clone cppcheck to install (Ubuntu)
-        if: contains(matrix.os, 'ubuntu') && steps.cache_cppcheck.outputs.cache-hit != 'true'
+      - name: Clone cppcheck to install
+        if: steps.cache_cppcheck.outputs.cache-hit != 'true'
         run: |
           git clone --depth=1 https://github.com/danmar/cppcheck.git
 
-      - name: Build cppcheck (Ubuntu)
-        if: contains(matrix.os, 'ubuntu') && steps.cache_cppcheck.outputs.cache-hit != 'true'
+      - name: Build cppcheck
+        if: steps.cache_cppcheck.outputs.cache-hit != 'true'
         run: |
           cd cppcheck
           sudo make ${{ env.CPPCHECK_MAKE_OPTIONS }} all
 
-      - name: Install cppcheck (Ubuntu)
-        if: contains(matrix.os, 'ubuntu')
+      - name: Install cppcheck
         run: |
           cd cppcheck
           sudo make ${{ env.CPPCHECK_MAKE_OPTIONS }} install

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   schedule:
     - cron: 0 20 * * 5
+  workflow_dispatch:
 
 jobs:
   cppcheck:

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -18,7 +18,7 @@ jobs:
       CPPCHECK_MAKE_OPTIONS: -k -j MATCHCOMPILER=yes FILESDIR=/usr/share/cppcheck HAVE_RULES=yes CXXFLAGS='-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Cache cppcheck (Ubuntu)
         if: contains(matrix.os, 'ubuntu')

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -10,34 +10,12 @@ jobs:
   cppcheck:
     runs-on: ubuntu-latest
 
-    env:
-      CPPCHECK_MAKE_OPTIONS: -k -j MATCHCOMPILER=yes FILESDIR=/usr/share/cppcheck HAVE_RULES=yes CXXFLAGS='-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function'
-
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache cppcheck
-        id: cache_cppcheck
-        uses: actions/cache@v2
-        with:
-          path: cppcheck
-          key: cppcheck_cache_${{ runner.os }}_v1
-
-      - name: Clone cppcheck to install
-        if: steps.cache_cppcheck.outputs.cache-hit != 'true'
-        run: |
-          git clone --depth=1 https://github.com/danmar/cppcheck.git
-
-      - name: Build cppcheck
-        if: steps.cache_cppcheck.outputs.cache-hit != 'true'
-        run: |
-          cd cppcheck
-          sudo make ${{ env.CPPCHECK_MAKE_OPTIONS }} all
-
       - name: Install cppcheck
         run: |
-          cd cppcheck
-          sudo make ${{ env.CPPCHECK_MAKE_OPTIONS }} install
+          sudo apt install cppcheck
 
       - name: Run cppcheck
         run: |

--- a/.github/workflows/cpplint.yml
+++ b/.github/workflows/cpplint.yml
@@ -3,19 +3,19 @@ name: cpplint
 on:
   pull_request:
   schedule:
-    - cron:  0 20 * * 5
+    - cron: 0 20 * * 5
 
 jobs:
   cpplint:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Install cpplint.py
-      run: |
-        git clone --depth=1 https://github.com/cpplint/cpplint.git
+      - name: Install cpplint.py
+        run: |
+          git clone --depth=1 https://github.com/cpplint/cpplint.git
 
-    - name: cpplint
-      run: |
-        make CPPLINT=cpplint/cpplint.py -k -j cpplint
+      - name: cpplint
+        run: |
+          make CPPLINT=cpplint/cpplint.py -k -j cpplint

--- a/.github/workflows/cpplint.yml
+++ b/.github/workflows/cpplint.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   schedule:
     - cron: 0 20 * * 5
+  workflow_dispatch:
 
 jobs:
   cpplint:

--- a/.github/workflows/cpplint.yml
+++ b/.github/workflows/cpplint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install cpplint.py
         run: |

--- a/.github/workflows/deploy_github_pages.yml
+++ b/.github/workflows/deploy_github_pages.yml
@@ -11,32 +11,32 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-    - uses: actions/checkout@v1
+      - uses: actions/checkout@v1
 
-    - name: Install gcovr
-      run: |
-        sudo pip3 install gcovr
+      - name: Install gcovr
+        run: |
+          sudo pip3 install gcovr
 
-    - name: Install graphviz and doxygen
-      run: |
-        sudo apt update
-        sudo apt install -y --no-install-recommends graphviz doxygen
+      - name: Install graphviz and doxygen
+        run: |
+          sudo apt update
+          sudo apt install -y --no-install-recommends graphviz doxygen
 
-    - name: Install googletest
-      run: |
-        git clone https://github.com/google/googletest.git
-        cd googletest
-        cmake -DBUILD_GMOCK=OFF -DCMAKE_CXX_STANDARD=11 .
-        sudo make -k -j all install
-        cd ..
-        rm -rf googletest
+      - name: Install googletest
+        run: |
+          git clone https://github.com/google/googletest.git
+          cd googletest
+          cmake -DBUILD_GMOCK=OFF -DCMAKE_CXX_STANDARD=11 .
+          sudo make -k -j all install
+          cd ..
+          rm -rf googletest
 
-    - name: Build site
-      run: |
-        make BUILD_TYPE=coverage -k -j site
+      - name: Build site
+        run: |
+          make BUILD_TYPE=coverage -k -j site
 
-    - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./out/site
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./out/site

--- a/.github/workflows/deploy_github_pages.yml
+++ b/.github/workflows/deploy_github_pages.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: Install gcovr
         run: |

--- a/.github/workflows/markdown_lint.yml
+++ b/.github/workflows/markdown_lint.yml
@@ -3,13 +3,13 @@ name: Markdown lint
 on:
   pull_request:
   schedule:
-    - cron:  0 20 * * 5
+    - cron: 0 20 * * 5
 
 jobs:
   markdown-lint:
     name: Lint markdown files.
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - uses: actionshub/markdownlint@main
+      - uses: actionshub/markdownlint@main

--- a/.github/workflows/markdown_lint.yml
+++ b/.github/workflows/markdown_lint.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   schedule:
     - cron: 0 20 * * 5
+  workflow_dispatch:
 
 jobs:
   markdown-lint:

--- a/.github/workflows/markdown_lint.yml
+++ b/.github/workflows/markdown_lint.yml
@@ -11,6 +11,6 @@ jobs:
     name: Lint markdown files.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actionshub/markdownlint@main

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ CPPLINT := cpplint.py
 
 CPPLINT_FLAGS :=
 CPPLINT_FLAGS += --quiet
-CPPLINT_FLAGS += --filter=-build/include
+CPPLINT_FLAGS += --filter=-build/include,-whitespace/indent_namespace
 
 CPPLINT_TARGET_FILES :=
 CPPLINT_TARGET_FILES += $(ALL_SRC_CPP)

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ WARNING_CXXFLAGS += -Wno-error=inline
 
 # Build C++ compiler flags for test.
 TEST_CXXFLAGS := $(CXXFLAGS)
-TEST_CXXFLAGS += --std=c++11
+TEST_CXXFLAGS += --std=c++17
 TEST_CXXFLAGS += $(addprefix -I, $(INCLUDE_DIR))
 TEST_CXXFLAGS += $(addprefix -I, $(SYSTEM_INCLUDE_DIRS))
 TEST_CXXFLAGS += $(BUILD_TYPE_CXXFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -109,12 +109,12 @@ WARNING_CXXFLAGS += -Wno-error=inline
 # WARNING_CXXFLAGS += -Wstrict-prototypes
 
 # Build C++ compiler flags for test.
-MY_CXXFLAGS := $(CXXFLAGS)
-MY_CXXFLAGS += --std=c++11
-MY_CXXFLAGS += $(addprefix -I, $(INCLUDE_DIR))
-MY_CXXFLAGS += $(addprefix -I, $(SYSTEM_INCLUDE_DIRS))
-MY_CXXFLAGS += $(BUILD_TYPE_CXXFLAGS)
-MY_CXXFLAGS += $(WARNING_CXXFLAGS)
+TEST_CXXFLAGS := $(CXXFLAGS)
+TEST_CXXFLAGS += --std=c++11
+TEST_CXXFLAGS += $(addprefix -I, $(INCLUDE_DIR))
+TEST_CXXFLAGS += $(addprefix -I, $(SYSTEM_INCLUDE_DIRS))
+TEST_CXXFLAGS += $(BUILD_TYPE_CXXFLAGS)
+TEST_CXXFLAGS += $(WARNING_CXXFLAGS)
 
 # Site config.
 SITE_SRC_DIR := site_src
@@ -213,11 +213,11 @@ site: $(SITE_OUT_INDEX_HTML) doxygen coverage
 
 $(TEST_EXEC): $(TEST_OBJS)
 	@mkdir -p $(dir $@)
-	$(CXX) -o $(TEST_EXEC) $^ $(LDFLAGS) $(TEST_LDFLAGS) $(MY_CXXFLAGS)
+	$(CXX) -o $(TEST_EXEC) $^ $(LDFLAGS) $(TEST_LDFLAGS) $(TEST_CXXFLAGS)
 
 $(TEST_OBJ_DIR)%.o: $(TEST_SRC_DIR)/%.cc
 	@mkdir -p $(dir $@)
-	$(CXX) $(MY_CXXFLAGS) -o $@ -c $< -MMD -MP
+	$(CXX) $(TEST_CXXFLAGS) -o $@ -c $< -MMD -MP
 
 
 %.cpplint: .FORCE

--- a/build/Doxyfile
+++ b/build/Doxyfile
@@ -829,7 +829,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = include sample test
+INPUT                  = include test
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/build/cppcheck_suppression.txt
+++ b/build/cppcheck_suppression.txt
@@ -1,3 +1,4 @@
 missingInclude
+missingIncludeSystem
 unmatchedSuppression
 unusedFunction

--- a/build/win_vs/libsatop/libsatop_test/libsatop_test.vcxproj
+++ b/build/win_vs/libsatop/libsatop_test/libsatop_test.vcxproj
@@ -21,9 +21,9 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{28140122-1529-452e-8ab8-b7339b428086}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <ProjectName>libsatop_test</ProjectName>
   </PropertyGroup>
@@ -50,9 +50,6 @@
     <IntDir>..\..\..\..\out\$(PlatformShortName)\$(Configuration)\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ClCompile Include="..\..\..\..\test\gtest_compat.cc">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">gtest_compat.h</PrecompiledHeaderFile>
@@ -65,10 +62,13 @@
     </ClCompile>
     <ClCompile Include="..\..\..\..\test\test_add.cc" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <ItemDefinitionGroup />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.3\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.3\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
+    <Import Project="..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.7\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.7\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
   </ImportGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -148,6 +148,6 @@
     <PropertyGroup>
       <ErrorText>このプロジェクトは、このコンピューター上にない NuGet パッケージを参照しています。それらのパッケージをダウンロードするには、[NuGet パッケージの復元] を使用します。詳細については、http://go.microsoft.com/fwlink/?LinkID=322105 を参照してください。見つからないファイルは {0} です。</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.3\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.3\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.7\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.7\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
   </Target>
 </Project>

--- a/build/win_vs/libsatop/libsatop_test/packages.config
+++ b/build/win_vs/libsatop/libsatop_test/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1.3" targetFramework="native" />
+  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1.7" targetFramework="native" />
 </packages>

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 libsatop is a Library for saturated arithmetic operation by C++11.
 
-![](https://github.com/MinoruSekine/libsatop/workflows/Check%20build/badge.svg?branch=main)
+![](https://github.com/MinoruSekine/libsatop/actions/workflows/check_build.yml/badge.svg?branch=main)
 
 ## API Reference
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,14 +25,14 @@ Makefile of libsatop will provide followings on your environments
 
 - Build and run unit tests
 - Some checks
-  - Coding rule check by cpplint
-  - Static analysis by cppcheck
+   - Coding rule check by cpplint
+   - Static analysis by cppcheck
 - Build documents with Doxygen
 
 ### List of build targets
 
 | `make` target | How it works |
-----|----
+| ---- | ---- |
 | `all` | Same as `build-all` |
 | `build-all` | Same as `build-test` |
 | `build-test` | Build unit tests |
@@ -54,7 +54,7 @@ Makefile of libsatop will provide followings on your environments
 #### `BUILD_TYPE`
 
 | `BUILD_TYPE` | How it works |
-----|----
+| ---- | ---- |
 | `debug` | All optimizations are disabled in build |
 | `release` | Optimizations are enabled in build |
 | `coverage` | Options for build `coverage` as `make` target |
@@ -111,7 +111,7 @@ As of 2021/04/30,
 all tests succeed on following environments
 
 | OS | Compiler |
-----|----
+| ---- | ---- |
 | macOS Catalina 10.15.7 | g++ (symlink to clang) |
 | Ubuntu 16.04 | g++ |
 | Ubuntu 18.04 | g++ |


### PR DESCRIPTION
# Summary

- feat: Enable manually invoking GitHub Actions workflows. (#34)
- Updated broken cppcheck workflow
- Resolved some little formatting issues in YAML

# Details

- feat: Enable manually invoking GitHub Actions workflows. (#34)
- Updated some broken workflows
   - cppcheck workflow
      - Fixed to run on only ubuntu-latest
      - Use cppcheck installed by apt instead of self-built
- Updated actions/checkout from @v1 or @v2 to @v4 (current latest major version)
- Resolved some little formatting issues in YAML
   - Indent
   - Spacing

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [X] CI

# References

- #34 

# Notes

- N/A
