### PR TITLE
fix: Resolved broken GitHub Pages deployments. (#33)

### DIFF
--- a/.github/workflows/deploy_github_pages.yml
+++ b/.github/workflows/deploy_github_pages.yml
@@ -7,11 +7,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
-    runs-on: ubuntu-18.04
+  upload_artifact:
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Install gcovr
         run: |
@@ -35,8 +36,23 @@ jobs:
         run: |
           make BUILD_TYPE=coverage -k -j site
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3.0.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./out/site
+
+  deploy:
+    needs: upload_artifact
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4.0.5


### PR DESCRIPTION
# Summary

- Resolves broken GitHubPages Deployments

# Details

- Updated very old `ubuntu-18.04` runner to available latest runner
- Updated official actions to deploy GitHub Pages

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# References

- #33 

# Notes

- N/A
