### PR TITLE
fix: `Doxygen` workflow error by using legacy upload-artifact. (#38)

### DIFF
--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -24,7 +24,7 @@ jobs:
           make -k -j doxygen latex pdf
 
       - name: Upload Doxygen documents
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: doc
           path: out/site/Doxygen


### PR DESCRIPTION
# Summary

- Resolved `Doxygen` workflow error

# Details

- Resolved `Doxygen` workflow error by using legacy `actions/upload-artifact `

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# References

- #38 

# Notes

- N/A
