### PR TITLE
fix: cppcheck error for always false in constexpr func (#41)

### DIFF
--- a/include/satop_add-priv.h
+++ b/include/satop_add-priv.h
@@ -37,18 +37,9 @@ constexpr bool is_add_overflow(T x, T y) {
 }
 
 template <typename T>
-constexpr bool is_add_underflow(
-    T x,
-    typename std::enable_if<std::is_unsigned<T>::value, T>::type y) {
-  return static_cast<void>(x), static_cast<void>(y), false;
-}
-
-template <typename T>
-constexpr bool is_add_underflow(
-    T x,
-    typename std::enable_if<std::is_signed<T>::value, T>::type y) {
-  return ((x < 0)
-          && (y < 0)
+constexpr bool is_add_underflow(T x, T y) {
+  return (!(x >= 0)
+          && !(y >= 0)
           && ((x < std::numeric_limits<T>::lowest() - y)
               || (y < std::numeric_limits<T>::lowest() - x)));
 }


### PR DESCRIPTION
# Summary

- cppcheck `knownConditionTrueFalse` error for always false condition in constexpr function

# Details

- `bool is add_overflow<>()` specialized to `unsigned` types returns always `false`
   - I can suppress this, but I removed `unsigned` specialization, and resolved warnings in unified `bool is add_overflow<>()`

# Continuous operation guarantee by

- [x] Unit tests
  - [x] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# References

- #41

# Notes

- N/A
